### PR TITLE
Old CoffeeScript, and nested requires

### DIFF
--- a/lib/coffee-cache.js
+++ b/lib/coffee-cache.js
@@ -17,10 +17,13 @@ var cacheDir = process.env['COFFEE_CACHE_DIR'] || '.coffee';
 // Storing coffee's require extension for backup use
 var coffeeExtension = require.extensions['.coffee'];
 
-var wrapCompiled = function(content, filename, header) {
+var wrapCompiled = function(content, filename, header, module) {
   // If we want to modify the header to include our source map, we must
   // overwrite the static Module.wrapper and then restore it. Ugly, but it's a
   // quick fix
+  // We're taking module as an argument because we need to _compile with the module
+  // of the thing being compiled, rather than with coffee-cache's module, or relative
+  // paths will be all sorts of messed up
   var wrapMethod = module.constructor.wrap;
   module.constructor.wrap = function(script){
     return (header || '') + wrapMethod(script);
@@ -69,7 +72,11 @@ require.extensions['.coffee'] = function(module, filename) {
       });
       content = compiled.js;
 
-      if (compiled.v3SourceMap)
+      // Since we don't know which version of CoffeeScript we have, make sure
+      // we handle the older versions that return just the compiled version.
+      if (content == null)
+        content = compiled;
+      else if (compiled.v3SourceMap)
         header = sourceMapHeader(mapPath);
 
       // Try writing to cache
@@ -84,7 +91,7 @@ require.extensions['.coffee'] = function(module, filename) {
     }
   }
 
-  return wrapCompiled(content, filename, header);
+  return wrapCompiled(content, filename, header, module);
 };
 
 // Export settings


### PR DESCRIPTION
In older versions of CoffeeScript, compiling returns just the compiled version rather than an object (since it didn't support source maps yet).

Also, nested coffee-script requires (with relative paths) were failing because we were passing the wrong `module` object as `this` to `_compile`.
