### PR TITLE
Added ability to specifiy root directory

### DIFF
--- a/lib/coffee-cache.js
+++ b/lib/coffee-cache.js
@@ -18,6 +18,10 @@ try {
 
 // Directory to store compiled source
 var cacheDir = process.env['COFFEE_CACHE_DIR'] || '.coffee';
+
+// Root directory of project - use __dirname by default
+var rootDir = process.env['COFFEE_ROOT_DIR'] || '.';
+
 // Storing coffee's require extension for backup use
 var coffeeExtension = require.extensions['.coffee'];
 
@@ -26,7 +30,7 @@ var coffeeExtension = require.extensions['.coffee'];
 require.extensions['.coffee'] = function(module, filename) {
   // First, convert the filename to something more digestible and use our cache
   // folder
-  var cachePath = path.join(cacheDir, path.relative('.', filename)).replace(/\.coffee$/, '.js');
+  var cachePath = path.join(cacheDir, path.relative(rootDir, filename)).replace(/\.coffee$/, '.js');
   var mapPath = path.resolve(cachePath.replace(/\.js$/, '.map'));
   var content;
 
@@ -74,7 +78,11 @@ require.extensions['.coffee'] = function(module, filename) {
 
 // Export settings
 module.exports = {
-  setCacheDir: function(dir){
+  setCacheDir: function(dir, root){
+    if(root) {
+      rootDir = root;
+    }
+
     cacheDir = dir;
     return this;
   }


### PR DESCRIPTION
This fixes issues when files are being required from a directory which is above `__dirname`.

Resolving `path.join(cacheDir, path.relative('.', filename))` where  `cacheDir = '../.coffee/'` and `filename = '../common/example.js'` = `../common/example.js` 

where as we actually want `../.coffee/common/example.js`
