### PR TITLE
Tell the user if they can't write the coffee cache

### DIFF
--- a/lib/coffee-cache.js
+++ b/lib/coffee-cache.js
@@ -25,6 +25,14 @@ var rootDir = process.env['COFFEE_ROOT_DIR'] || '.';
 // Storing coffee's require extension for backup use
 var coffeeExtension = require.extensions['.coffee'];
 
+// Only log once if we can't write the cache directory
+var logCouldNotWriteCache = function() {
+  process.stderr.write(
+    "coffee-cache: Could not write cache at " + cacheDir + ".\n"
+  );
+  logCouldNotWriteCache = function(){};
+}
+
 // Compile a file as you would with require and return the contents
 function cacheFile(filename) {
   // First, convert the filename to something more digestible and use our cache
@@ -66,7 +74,7 @@ function cacheFile(filename) {
       if (mapPath)
         fs.writeFileSync(mapPath, compiled.v3SourceMap, 'utf8');
     } catch (err) {
-      // Let's fail silently and just return the content we got
+      logCouldNotWriteCache()
     }
   }
 


### PR DESCRIPTION
It's fairly easy to get into a situation wherein the user attempting to
run the coffeescript does not have permission to write the cache dir. We
don't want to change the behavior of the package too much, so let's just
log a message to stderr and continue, rather than exiting.