### PR TITLE
Small performance cleanup.

### DIFF
--- a/lib/coffee-cache.js
+++ b/lib/coffee-cache.js
@@ -38,13 +38,12 @@ function cacheFile(filename) {
   // First, convert the filename to something more digestible and use our cache
   // folder
   var cachePath = path.join(cacheDir, path.relative(rootDir, filename)).replace(/\.coffee$/, '.js');
-  var mapPath = path.resolve(cachePath.replace(/\.js$/, '.map'));
   var content;
 
   // Try and stat the files for their last modified time
   try {
-    var sourceTime = fs.statSync(filename).mtime;
     var cacheTime = fs.statSync(cachePath).mtime;
+    var sourceTime = fs.statSync(filename).mtime;
     if (cacheTime > sourceTime) {
       // We can return the cached version
       content = fs.readFileSync(cachePath, 'utf8');
@@ -57,6 +56,7 @@ function cacheFile(filename) {
   if (!content) {
     try {
       // Read from disk and then compile
+      var mapPath = path.resolve(cachePath.replace(/\.js$/, '.map'));
       var compiled = coffee.compile(fs.readFileSync(filename, 'utf8'), {
         filename: filename,
         sourceMap: true


### PR DESCRIPTION
Stat the cache file first, so that we quicker go to the compile branch. The
source file will always exist.

Move the mapPath var to the scope where it is used so that we skip building
it on cache hits.