### PR TITLE
fix: compile error shouldn't be treated as file permission error

### DIFF
--- a/lib/coffee-cache.js
+++ b/lib/coffee-cache.js
@@ -54,20 +54,20 @@ function cacheFile(filename) {
 
   // If we don't have the content, we need to compile ourselves
   if (!content) {
+    // Read from disk and then compile
+    var mapPath = path.resolve(cachePath.replace(/\.js$/, '.map'));
+    var compiled = coffee.compile(fs.readFileSync(filename, 'utf8'), {
+      filename: filename,
+      sourceMap: true
+    });
+    content = compiled.js;
+
+    // Since we don't know which version of CoffeeScript we have, make sure
+    // we handle the older versions that return just the compiled version.
+    if (content == null)
+      content = compiled;
+
     try {
-      // Read from disk and then compile
-      var mapPath = path.resolve(cachePath.replace(/\.js$/, '.map'));
-      var compiled = coffee.compile(fs.readFileSync(filename, 'utf8'), {
-        filename: filename,
-        sourceMap: true
-      });
-      content = compiled.js;
-
-      // Since we don't know which version of CoffeeScript we have, make sure
-      // we handle the older versions that return just the compiled version.
-      if (content == null)
-        content = compiled;
-
       // Try writing to cache
       mkpath.sync(path.dirname(cachePath));
       fs.writeFileSync(cachePath, content, 'utf8');


### PR DESCRIPTION
When the required coffee file has some syntax error, it only reports `coffee-cache: Could not write cache at`.
This will apparently mislead users.